### PR TITLE
Use advanced xmlrpc-c to fix debug logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,41 @@
 FROM alpine:3.10
 LABEL maintainer="looselyrigorous <looselyrigorous@gmail.com>"
+ARG BUILD_CORES
 
 # Install rtorrent and su-exec
 # Create necessary folders
-# Forward Info & Error logs to std{out,err} (à la nginx)
-RUN apk add --no-cache \
-      rtorrent \
-      su-exec && \
-    mkdir -p \
+# Forward Info & Error logs to std{out,err} (à la nginx)a
+RUN NB_CORES=${BUILD_CORES-`getconf _NPROCESSORS_CONF`} \
+ && apk -U upgrade \
+ && apk add -t build-dependencies \
+    build-base \
+    git \
+    libtool \
+    automake \
+    autoconf \
+    wget \
+    tar \
+    xz \
+    zlib-dev \
+    cppunit-dev \
+    openssl-dev \
+    binutils \
+    linux-headers \
+    ca-certificates \
+    curl \
+    openssl \
+    gzip \
+    zip \
+    zlib \
+ && apk add \
+    su-exec \
+    rtorrent \
+ && cd /tmp \
+ && git clone https://github.com/mirror/xmlrpc-c.git \
+ && cd /tmp/xmlrpc-c/advanced && ./configure && make -j ${NB_CORES} && make install \
+ && apk del build-dependencies \
+ && rm -rf /var/cache/apk/* /tmp/* \
+ && mkdir -p \
       /dist \
       /config \
       /session \


### PR DESCRIPTION
* See [this issue](https://github.com/rakshasa/rtorrent/issues/861) for background on the problem

The alpine-packaged (even alpine edge as of right now) version of the xmlrpc-c package has some debugging turned on which causes an incredibly large amount of logging output by the rtorrent process.  The only way to fix this, right now, is to use the 'xmlrpc advanced' version of xmlrpc-c.

The way to use this is to compile this package at Docker build time.  The modifications here remove all of the build tools used for compiling the package to keep container image as small as possible.